### PR TITLE
fix: use job obj directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "contributors": [],
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.9.1",
+    "eslint": "^3.19.0",
     "eslint-config-screwdriver": "^2.0.9",
     "jenkins-mocha": "^3.0.0",
     "mockery": "^2.1.0",


### PR DESCRIPTION
We have this information from here: https://github.com/screwdriver-cd/models/blob/master/lib/buildFactory.js#L248-L249

Related: 
https://github.com/screwdriver-cd/screwdriver/issues/1284
https://github.com/screwdriver-cd/screwdriver/issues/1257