### PR TITLE
fix: fix empty command

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ class CacheBookend extends BookendInterface {
             return Promise.resolve(eventMap.join(' ; '));
         }
 
-        return Promise.resolve('');
+        return Promise.resolve('echo skipping cache');
     }
 
     /**
@@ -47,7 +47,7 @@ class CacheBookend extends BookendInterface {
             return Promise.resolve(eventMap.join(' ; '));
         }
 
-        return Promise.resolve('');
+        return Promise.resolve('echo skipping cache');
     }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -49,7 +49,7 @@ describe('index test', () => {
         bookend.getSetupCommand({
             job: { permutations: [{}] }
         }).then(result =>
-            assert.strictEqual(result, '')
+            assert.strictEqual(result, 'echo skipping cache')
         )
     );
 
@@ -57,7 +57,7 @@ describe('index test', () => {
         bookend.getTeardownCommand({
             job: { permutations: [{}] }
         }).then(result =>
-            assert.strictEqual(result, '')
+            assert.strictEqual(result, 'echo skipping cache')
         )
     );
 });


### PR DESCRIPTION
To fix this error: 
```
{"statusCode":500,"error":"Internal Server Error","message":"\"List of builds\" at position 0 fails because [child \"steps\" fails because [\"steps\" at position 2 fails because [child \"command\" fails because [\"command\" is not allowed to be empty]]]]"}
```