### PR TITLE
feat: update hapi dependencies. BREAKING CHANGE: fetch new packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const hoek = require('hoek');
+const hoek = require('@hapi/hoek');
 const { BookendInterface } = require('screwdriver-build-bookend');
 
 /**
@@ -13,9 +13,7 @@ const { BookendInterface } = require('screwdriver-build-bookend');
  */
 function getCacheCommands(cache, scope, action) {
     if (cache && cache.length > 0) {
-        const cmds = cache.map(item =>
-            `store-cli ${action} ${item} --type=cache --scope=${scope} || true`
-        );
+        const cmds = cache.map(item => `store-cli ${action} ${item} --type=cache --scope=${scope} || true`);
 
         return cmds.join(' ; ');
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -23,16 +23,16 @@
   "contributors": [],
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^5.9.0",
-    "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^6.0.0",
+    "eslint": "^7.5.0",
+    "eslint-config-screwdriver": "^5.0.1",
+    "mocha": "^8.1.1",
     "mockery": "^2.1.0",
     "sinon": "^7.0.0"
   },
   "dependencies": {
-    "screwdriver-build-bookend": "^2.1.1",
+    "@hapi/hoek": "^9.0.4",
     "request": "^2.88.0",
-    "hoek": "^5.0.4"
+    "screwdriver-build-bookend": "^2.1.1"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-cache-bookend",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "sd.cd bookend for restoring build cache",
   "main": "index.js",
   "scripts": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:12
 
 jobs:
     main:

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,84 +20,114 @@ describe('index test', () => {
     });
 
     it('getSetupCommand', () =>
-        bookend.getSetupCommand({
-            job: { permutations: [{
-                cache: {
-                    event: ['/foo/bar', '/bar/baz']
+        bookend
+            .getSetupCommand({
+                job: {
+                    permutations: [
+                        {
+                            cache: {
+                                event: ['/foo/bar', '/bar/baz']
+                            }
+                        }
+                    ]
                 }
-            }] } }).then(result =>
-            assert.strictEqual(result,
-                'echo skipping pipeline cache ; ' +
-                'store-cli get /foo/bar --type=cache --scope=event || true ; ' +
-                'store-cli get /bar/baz --type=cache --scope=event || true ; ' +
-                'echo skipping job cache')
-        )
-    );
+            })
+            .then(result =>
+                assert.strictEqual(
+                    result,
+                    'echo skipping pipeline cache ; ' +
+                        'store-cli get /foo/bar --type=cache --scope=event || true ; ' +
+                        'store-cli get /bar/baz --type=cache --scope=event || true ; ' +
+                        'echo skipping job cache'
+                )
+            ));
 
     it('getSetupCommand with pipeline, job, and event', () =>
-        bookend.getSetupCommand({
-            job: { permutations: [{
-                cache: {
-                    event: ['/foo/bar', '/bar/baz'],
-                    pipeline: ['/a/b/c'],
-                    job: ['/d/f', '/g']
+        bookend
+            .getSetupCommand({
+                job: {
+                    permutations: [
+                        {
+                            cache: {
+                                event: ['/foo/bar', '/bar/baz'],
+                                pipeline: ['/a/b/c'],
+                                job: ['/d/f', '/g']
+                            }
+                        }
+                    ]
                 }
-            }] } }).then(result =>
-            assert.strictEqual(result,
-                'store-cli get /a/b/c --type=cache --scope=pipeline || true ; ' +
-                'store-cli get /foo/bar --type=cache --scope=event || true ; ' +
-                'store-cli get /bar/baz --type=cache --scope=event || true ; ' +
-                'store-cli get /d/f --type=cache --scope=job || true ; ' +
-                'store-cli get /g --type=cache --scope=job || true')
-        )
-    );
+            })
+            .then(result =>
+                assert.strictEqual(
+                    result,
+                    'store-cli get /a/b/c --type=cache --scope=pipeline || true ; ' +
+                        'store-cli get /foo/bar --type=cache --scope=event || true ; ' +
+                        'store-cli get /bar/baz --type=cache --scope=event || true ; ' +
+                        'store-cli get /d/f --type=cache --scope=job || true ; ' +
+                        'store-cli get /g --type=cache --scope=job || true'
+                )
+            ));
 
     it('getTeardownCommand', () =>
-        bookend.getTeardownCommand({
-            job: { permutations: [{
-                cache: {
-                    event: ['/foo/bar', '/bar/baz']
+        bookend
+            .getTeardownCommand({
+                job: {
+                    permutations: [
+                        {
+                            cache: {
+                                event: ['/foo/bar', '/bar/baz']
+                            }
+                        }
+                    ]
                 }
-            }] } }).then(result =>
-            assert.strictEqual(result,
-                'echo skipping pipeline cache ; ' +
-                'store-cli set /foo/bar --type=cache --scope=event || true ; ' +
-                'store-cli set /bar/baz --type=cache --scope=event || true ; ' +
-                'echo skipping job cache')
-        )
-    );
+            })
+            .then(result =>
+                assert.strictEqual(
+                    result,
+                    'echo skipping pipeline cache ; ' +
+                        'store-cli set /foo/bar --type=cache --scope=event || true ; ' +
+                        'store-cli set /bar/baz --type=cache --scope=event || true ; ' +
+                        'echo skipping job cache'
+                )
+            ));
 
     it('getTeardownCommand with pipeline, job, and event', () =>
-        bookend.getTeardownCommand({
-            job: { permutations: [{
-                cache: {
-                    event: ['/foo/bar', '/bar/baz'],
-                    pipeline: ['/a/b/c'],
-                    job: ['/d/f', '/g']
+        bookend
+            .getTeardownCommand({
+                job: {
+                    permutations: [
+                        {
+                            cache: {
+                                event: ['/foo/bar', '/bar/baz'],
+                                pipeline: ['/a/b/c'],
+                                job: ['/d/f', '/g']
+                            }
+                        }
+                    ]
                 }
-            }] } }).then(result =>
-            assert.strictEqual(result,
-                'store-cli set /a/b/c --type=cache --scope=pipeline || true ; ' +
-                'store-cli set /foo/bar --type=cache --scope=event || true ; ' +
-                'store-cli set /bar/baz --type=cache --scope=event || true ; ' +
-                'store-cli set /d/f --type=cache --scope=job || true ; ' +
-                'store-cli set /g --type=cache --scope=job || true')
-        )
-    );
+            })
+            .then(result =>
+                assert.strictEqual(
+                    result,
+                    'store-cli set /a/b/c --type=cache --scope=pipeline || true ; ' +
+                        'store-cli set /foo/bar --type=cache --scope=event || true ; ' +
+                        'store-cli set /bar/baz --type=cache --scope=event || true ; ' +
+                        'store-cli set /d/f --type=cache --scope=job || true ; ' +
+                        'store-cli set /g --type=cache --scope=job || true'
+                )
+            ));
 
     it('getSetupCommand resolves to empty', () =>
-        bookend.getSetupCommand({
-            job: { permutations: [{}] }
-        }).then(result =>
-            assert.strictEqual(result, 'echo skipping cache')
-        )
-    );
+        bookend
+            .getSetupCommand({
+                job: { permutations: [{}] }
+            })
+            .then(result => assert.strictEqual(result, 'echo skipping cache')));
 
     it('getTeardownCommand resolves to empty', () =>
-        bookend.getTeardownCommand({
-            job: { permutations: [{}] }
-        }).then(result =>
-            assert.strictEqual(result, 'echo skipping cache')
-        )
-    );
+        bookend
+            .getTeardownCommand({
+                job: { permutations: [{}] }
+            })
+            .then(result => assert.strictEqual(result, 'echo skipping cache')));
 });


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/hoek version and other changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
