### PR TITLE
fix(1961): Remove request package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
-    "request": "^2.88.0",
     "screwdriver-build-bookend": "^2.1.1"
   },
   "release": {


### PR DESCRIPTION
## Context

Request package is deprecated.

## Objective

This PR removes the unused request package from the package.json.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
