### PR TITLE
feat(2763): upgrade build-bookend module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "pretest": "eslint .",
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "./node_modules/.bin/semantic-release"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/cache-bookend.git"
+    "url": "git+https://github.com/screwdriver-cd/cache-bookend.git"
   },
   "homepage": "https://github.com/screwdriver-cd/cache-bookend",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -34,12 +34,12 @@
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.4",
-    "screwdriver-build-bookend": "^2.1.1"
+    "screwdriver-build-bookend": "^3.0.0"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "branches": [
+      "master"
+    ],
+    "debug": false
   }
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

`screwdriver-build-bookend@v3.0.0` has released.

https://github.com/screwdriver-cd/build-bookend/pull/22

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR upgrade `screwdriver-build-bookend` module version.
There are no changes to `BookendInterface` with [this upgrade](https://github.com/screwdriver-cd/build-bookend/compare/v2.4.0...v3.0.0).

And updates package.json to fix semantic release.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://cd.screwdriver.cd/pipelines/1/builds/827090/steps/duplicate

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
